### PR TITLE
Add C++ crackme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,42 @@
-# crackme_programs
+# Crackme Programs
+
+This repository contains three small C++ programs for practice with reverse engineering. Each program asks for a username and password and grants access when the correct combination is provided.
+
+## Levels
+
+- **lite** – straightforward check.
+- **simple** – obfuscated password check.
+- **strong** – includes anti-debugging and checksum verification.
+
+The valid credentials for each level are `admin` and `12345:<level>` where `<level>` is `lite`, `simple`, or `strong`.
+
+## Building
+
+### Ubuntu
+
+Use `g++` with C++17 support:
+
+```bash
+cd <level>
+g++ -std=c++17 -O2 main.cpp -o crackme
+```
+
+### Windows
+
+With Visual Studio developer command prompt:
+
+```cmd
+cd <level>
+cl /EHsc /std:c++17 main.cpp
+```
+
+Or with MinGW:
+
+```cmd
+cd <level>
+g++ -std=c++17 -O2 main.cpp -o crackme.exe
+```
+
+## Running
+
+Execute the built binary and enter the requested credentials. The programs exit with "Access granted" when the input matches the expected values.

--- a/lite/main.cpp
+++ b/lite/main.cpp
@@ -1,0 +1,19 @@
+#include <iostream>
+#include <string>
+
+int main() {
+    std::string username;
+    std::string password;
+
+    std::cout << "Username: ";
+    std::getline(std::cin, username);
+    std::cout << "Password: ";
+    std::getline(std::cin, password);
+
+    if (username == "admin" && password == "12345:lite") {
+        std::cout << "Access granted\n";
+    } else {
+        std::cout << "Access denied\n";
+    }
+    return 0;
+}

--- a/simple/main.cpp
+++ b/simple/main.cpp
@@ -1,0 +1,29 @@
+#include <iostream>
+#include <string>
+#include <vector>
+
+std::string decode_password() {
+    const int data[] = {100, 103, 102, 97, 96, 111, 38, 60, 56, 37, 57, 48};
+    std::string decoded;
+    for (int c : data) {
+        decoded += static_cast<char>(c ^ 0x55);
+    }
+    return decoded;
+}
+
+int main() {
+    std::string username;
+    std::string password;
+
+    std::cout << "Username: ";
+    std::getline(std::cin, username);
+    std::cout << "Password: ";
+    std::getline(std::cin, password);
+
+    if (username == "admin" && password == decode_password()) {
+        std::cout << "Access granted\n";
+    } else {
+        std::cout << "Access denied\n";
+    }
+    return 0;
+}

--- a/strong/main.cpp
+++ b/strong/main.cpp
@@ -1,0 +1,56 @@
+#include <iostream>
+#include <string>
+#include <cstdlib>
+#include <cstdint>
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <fstream>
+#endif
+
+bool is_debugger_attached() {
+#ifdef _WIN32
+    return IsDebuggerPresent();
+#else
+    std::ifstream status("/proc/self/status");
+    std::string line;
+    while (std::getline(status, line)) {
+        if (line.rfind("TracerPid:", 0) == 0) {
+            return line.find('0', 10) == std::string::npos;
+        }
+    }
+    return false;
+#endif
+}
+
+uint64_t checksum(const std::string& s) {
+    uint64_t sum = 0;
+    for (char c : s) {
+        sum = sum * 31 + static_cast<unsigned char>(c ^ 0xAA);
+    }
+    return sum;
+}
+
+int main() {
+    if (is_debugger_attached() || std::getenv("DEBUG")) {
+        std::cout << "Tampering detected!\n";
+        return 1;
+    }
+
+    std::string username;
+    std::string password;
+
+    std::cout << "Username: ";
+    std::getline(std::cin, username);
+    std::cout << "Password: ";
+    std::getline(std::cin, password);
+
+    const uint64_t expected = 4067081946268680494ULL; // checksum of 12345:strong
+
+    if (username == "admin" && checksum(password) == expected) {
+        std::cout << "Access granted\n";
+    } else {
+        std::cout << "Access denied\n";
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add crackme examples for lite, simple, and strong levels
- implement anti-debugging and checksum in strong level
- document build steps for Ubuntu and Windows

## Testing
- `g++ -std=c++17 -O2 main.cpp -o crackme_lite` within `lite`
- `./crackme_lite` tested with valid and invalid credentials
- `g++ -std=c++17 -O2 main.cpp -o crackme_simple` within `simple`
- `./crackme_simple` tested with valid and invalid credentials
- `g++ -std=c++17 -O2 main.cpp -o crackme_strong` within `strong`
- `./crackme_strong` tested with valid and invalid credentials and `DEBUG=1`

------
https://chatgpt.com/codex/tasks/task_e_688cc90cc5088333b85cb3037387c4b0